### PR TITLE
Make it possible to use PCD85063 or PCF85063.

### DIFF
--- a/PCF85063TP.cpp
+++ b/PCF85063TP.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//  Function: Header file for PCD85063TP
+//  Function: Header file for PCF85063TP
 //  Hardware: Grove - RTC v2.0
 //  Arduino IDE: Arduino-1.6.6
 //  Author:   FrankieChu
@@ -26,56 +26,56 @@
 #include <Wire.h>
 #include "PCF85063TP.h"
 
-uint8_t PCD85063TP::decToBcd(uint8_t val) {
+uint8_t PCF85063TP::decToBcd(uint8_t val) {
     return ((val / 10 * 16) + (val % 10));
 }
 
 //Convert binary coded decimal to normal decimal numbers
-uint8_t PCD85063TP::bcdToDec(uint8_t val) {
+uint8_t PCF85063TP::bcdToDec(uint8_t val) {
     return ((val / 16 * 10) + (val % 16));
 }
 
-void PCD85063TP::begin() {
+void PCF85063TP::begin() {
     Wire.begin();
     cap_sel(CAP_SEL_12_5PF);  // CAP_SEL bit setting 12.5pF
 
 }
 /*Function: The clock timing will start */
-void PCD85063TP::startClock(void) {      // set the ClockHalt bit low to start the rtc
+void PCF85063TP::startClock(void) {      // set the ClockHalt bit low to start the rtc
     uint8_t data;
-    Wire.beginTransmission(PCD85063TP_I2C_ADDRESS);
+    Wire.beginTransmission(PCF85063TP_I2C_ADDRESS);
     Wire.write((uint8_t)0x00);                      // Register 0x00 holds the oscillator start/stop bit
     Wire.endTransmission();
-    Wire.requestFrom(PCD85063TP_I2C_ADDRESS, 1);
+    Wire.requestFrom(PCF85063TP_I2C_ADDRESS, 1);
     data = Wire.read() &
            ~0x20;       // save actual control_1 regitser and AND sec with bit 7 (sart/stop bit) = clock started
-    Wire.beginTransmission(PCD85063TP_I2C_ADDRESS);
+    Wire.beginTransmission(PCF85063TP_I2C_ADDRESS);
     Wire.write((uint8_t)0x00);
     Wire.write((uint8_t)data);                    // write seconds back and start the clock
     Wire.endTransmission();
 }
 /*Function: The clock timing will stop */
-void PCD85063TP::stopClock(void) {       // set the ClockHalt bit high to stop the rtc
+void PCF85063TP::stopClock(void) {       // set the ClockHalt bit high to stop the rtc
     uint8_t data;
-    Wire.beginTransmission(PCD85063TP_I2C_ADDRESS);
+    Wire.beginTransmission(PCF85063TP_I2C_ADDRESS);
     Wire.write((uint8_t)0x00);                      // Register 0x00 holds the oscillator start/stop bit
     Wire.endTransmission();
-    Wire.requestFrom(PCD85063TP_I2C_ADDRESS, 1);
+    Wire.requestFrom(PCF85063TP_I2C_ADDRESS, 1);
     data = Wire.read() |
            0x20;       // save actual control_1 regitser and AND sec with bit 7 (sart/stop bit) = clock started
-    Wire.beginTransmission(PCD85063TP_I2C_ADDRESS);
+    Wire.beginTransmission(PCF85063TP_I2C_ADDRESS);
     Wire.write((uint8_t)0x00);
     Wire.write((uint8_t)data);                    // write seconds back and stop the clock
     Wire.endTransmission();
 }
 /****************************************************************/
 /*Function: Read time and date from RTC  */
-void PCD85063TP::getTime() {
+void PCF85063TP::getTime() {
     // Reset the register pointer
-    Wire.beginTransmission(PCD85063TP_I2C_ADDRESS);
+    Wire.beginTransmission(PCF85063TP_I2C_ADDRESS);
     Wire.write((uint8_t)0x04);
     Wire.endTransmission();
-    Wire.requestFrom(PCD85063TP_I2C_ADDRESS, 7);
+    Wire.requestFrom(PCF85063TP_I2C_ADDRESS, 7);
     // A few of these need masks because certain bits are control bits
     second     = bcdToDec(Wire.read() & 0x7f);
     minute     = bcdToDec(Wire.read());
@@ -87,7 +87,7 @@ void PCD85063TP::getTime() {
 }
 /*******************************************************************/
 /*Frunction: Write the time that includes the date to the RTC chip */
-void PCD85063TP::setTime() {
+void PCF85063TP::setTime() {
     writeReg(REG_SEC, decToBcd(second));// 0 to bit 7 starts the clock, bit 8 is OS reg
     writeReg(REG_MIN, decToBcd(minute));
     writeReg(REG_HOUR, decToBcd(hour));  // If you want 12 hour am/pm you need to set bit 6
@@ -96,23 +96,23 @@ void PCD85063TP::setTime() {
     writeReg(REG_MON, decToBcd(month));
     writeReg(REG_YEAR, decToBcd(year));
 }
-void PCD85063TP::fillByHMS(uint8_t _hour, uint8_t _minute, uint8_t _second) {
+void PCF85063TP::fillByHMS(uint8_t _hour, uint8_t _minute, uint8_t _second) {
     // assign variables
     hour = _hour;
     minute = _minute;
     second = _second;
 }
-void PCD85063TP::fillByYMD(uint16_t _year, uint8_t _month, uint8_t _day) {
+void PCF85063TP::fillByYMD(uint16_t _year, uint8_t _month, uint8_t _day) {
     year = _year - 2000;
     month = _month;
     dayOfMonth = _day;
 }
-void PCD85063TP::fillDayOfWeek(uint8_t _dow) {
+void PCF85063TP::fillDayOfWeek(uint8_t _dow) {
     dayOfWeek = _dow;
 }
 
-void PCD85063TP::reset() {
-    Wire.beginTransmission(PCD85063TP_I2C_ADDRESS);
+void PCF85063TP::reset() {
+    Wire.beginTransmission(PCF85063TP_I2C_ADDRESS);
     Wire.write((uint8_t)0x00);
     Wire.write(decToBcd(0x10));// software reset at bit 4
     Wire.endTransmission();
@@ -127,7 +127,7 @@ void PCD85063TP::reset() {
      If the RTC time too fast: offset_sec < 0
      If the RTC time too slow: offset_sec > 0
 */
-uint8_t PCD85063TP::calibratBySeconds(int mode, float offset_sec) {
+uint8_t PCF85063TP::calibratBySeconds(int mode, float offset_sec) {
     float Fmeas = 32768.0 + offset_sec * 32768.0;
     setcalibration(mode, Fmeas);
     return readCalibrationReg();
@@ -139,7 +139,7 @@ uint8_t PCD85063TP::calibratBySeconds(int mode, float offset_sec) {
           Fmeas: Real frequency you detect
 */
 
-void PCD85063TP::setcalibration(int mode, float Fmeas) {
+void PCF85063TP::setcalibration(int mode, float Fmeas) {
     float offset = 0;
     float Tmeas = 1.0 / Fmeas;
     float Dmeas = 1.0 / 32768 - Tmeas;
@@ -151,20 +151,20 @@ void PCD85063TP::setcalibration(int mode, float Fmeas) {
     }
 
     uint8_t data = (mode << 7) & 0x80 | ((int)(offset + 0.5) & 0x7f);
-    writeReg(PCD85063TP_OFFSET, data);
+    writeReg(PCF85063TP_OFFSET, data);
 }
 
 
-uint8_t PCD85063TP::readCalibrationReg(void) {
-    return readReg(PCD85063TP_OFFSET);
+uint8_t PCF85063TP::readCalibrationReg(void) {
+    return readReg(PCF85063TP_OFFSET);
 }
 
 
-void PCD85063TP::setRam(uint8_t value) {
+void PCF85063TP::setRam(uint8_t value) {
     writeReg(REG_RAM, value);
 }
 
-uint8_t PCD85063TP::readRamReg(void) {
+uint8_t PCF85063TP::readRamReg(void) {
     return readReg(REG_RAM);
 }
 
@@ -177,7 +177,7 @@ uint8_t PCD85063TP::readRamReg(void) {
                         1 - 12.5 pF
     @return: value of CAP_SEL bit
 */
-uint8_t PCD85063TP::cap_sel(uint8_t value) {
+uint8_t PCF85063TP::cap_sel(uint8_t value) {
     uint8_t control_1 = readReg(REG_CTRL1);
     control_1 = (control_1 & 0xFE) | (0x01 & value);
     writeReg(REG_CTRL1, control_1);
@@ -186,18 +186,18 @@ uint8_t PCD85063TP::cap_sel(uint8_t value) {
 }
 
 
-uint8_t PCD85063TP::readReg(uint8_t reg) {
-    Wire.beginTransmission(PCD85063TP_I2C_ADDRESS);
+uint8_t PCF85063TP::readReg(uint8_t reg) {
+    Wire.beginTransmission(PCF85063TP_I2C_ADDRESS);
     Wire.write(reg & 0xFF);
     Wire.endTransmission();
-    Wire.requestFrom(PCD85063TP_I2C_ADDRESS, 1);
+    Wire.requestFrom(PCF85063TP_I2C_ADDRESS, 1);
 
     return Wire.read();
 
 }
 
-void PCD85063TP::writeReg(uint8_t reg, uint8_t data) {
-    Wire.beginTransmission(PCD85063TP_I2C_ADDRESS);
+void PCF85063TP::writeReg(uint8_t reg, uint8_t data) {
+    Wire.beginTransmission(PCF85063TP_I2C_ADDRESS);
     Wire.write(reg & 0xFF);
     Wire.write(data & 0xFF);
     Wire.endTransmission();

--- a/PCF85063TP.h
+++ b/PCF85063TP.h
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//  Function: Header file for PCD85063TP
+//  Function: Header file for PCF85063TP
 //  Hardware: Grove - RTC v2.0
 //  Arduino IDE: Arduino-1.6.6
 //  Author:   FrankieChu
@@ -28,6 +28,8 @@
 
 #include <Arduino.h>
 
+#define PCF85063TP_I2C_ADDRESS 0x51
+#define PCF85063TP_OFFSET 0x02
 #define PCD85063TP_I2C_ADDRESS 0x51
 #define PCD85063TP_OFFSET 0x02
 #define REG_CTRL1         0x00
@@ -54,7 +56,7 @@
 #define SAT 6
 #define SUN 0
 
-class PCD85063TP {
+class PCF85063TP {
   private:
     uint8_t decToBcd(uint8_t val);
     uint8_t bcdToDec(uint8_t val);
@@ -86,5 +88,7 @@ class PCD85063TP {
     uint8_t readReg(uint8_t reg);
     void writeReg(uint8_t reg, uint8_t data);
 };
-
+// The typedef is because early versions of the library called it PCD85063TP
+// instead of PCF85063TP. This allows both class names to work.
+typedef PCF85063TP PCD85063TP;
 #endif

--- a/examples/SetAndDisplayRam/SetAndDisplayRam.ino
+++ b/examples/SetAndDisplayRam/SetAndDisplayRam.ino
@@ -1,5 +1,5 @@
 #include "PCF85063TP.h"
-PCD85063TP RTclock; // define a object of PCD85063TP class
+PCF85063TP RTclock; // define a object of PCD85063TP class
 
 void setup() {
   Serial.begin(9600);

--- a/examples/SetTimeAndDisplay/SetTimeAndDisplay.ino
+++ b/examples/SetTimeAndDisplay/SetTimeAndDisplay.ino
@@ -40,7 +40,7 @@ void setup() {
 
     */
     //clock.setcalibration(1, 32767.2);  // Setting offset by clock frequency
-    uint8_t ret = clock.calibratBySeconds(0, -0.000041);
+    uint8_t ret = RTclock.calibratBySeconds(0, -0.000041);
     Serial.print("offset value: ");
     Serial.print("0x");
     Serial.println(ret, HEX);
@@ -52,7 +52,7 @@ void loop() {
 }
 /*Function: Display time on the serial monitor*/
 void printTime() {
-    clock.getTime();
+    RTclock.getTime();
     Serial.print(RTclock.hour, DEC);
     Serial.print(":");
     Serial.print(RTclock.minute, DEC);


### PR DESCRIPTION
It seems that early versions of this library called the device PCD85063
instead of the current name of PCF85063. This typedef makes it possible
for both names to work.